### PR TITLE
Fix README.md example for secondary global indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Below is the User class declaration when we add a global secondary index to it:
  * @Item(
  *     table="users",
  *     primaryIndex={"id"},
- *     globalSecondaryIndex={
+ *     globalSecondaryIndices={
  *         @Index(hash="class", range="age", name="class-age-gsi")
  *     }
  * )


### PR DESCRIPTION
There is a mistake in the example docs for secondary indexes.